### PR TITLE
Manage snap errors

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/MultiplePointsNotFoundException.java
+++ b/core/src/main/java/com/graphhopper/routing/MultiplePointsNotFoundException.java
@@ -20,7 +20,7 @@ package com.graphhopper.routing;
 
 import com.carrotsearch.hppc.IntArrayList;
 
-class MultiplePointsNotFoundException extends RuntimeException {
+public class MultiplePointsNotFoundException extends RuntimeException {
 
     private final IntArrayList pointsNotFound;
 
@@ -28,7 +28,7 @@ class MultiplePointsNotFoundException extends RuntimeException {
         this.pointsNotFound = pointsNotFound;
     }
 
-    IntArrayList getPointsNotFound() {
+    public IntArrayList getPointsNotFound() {
         return pointsNotFound;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/ViaRouting.java
+++ b/core/src/main/java/com/graphhopper/routing/ViaRouting.java
@@ -22,6 +22,7 @@ import com.graphhopper.routing.ev.EncodedValueLookup;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.ev.RoadEnvironment;
+import com.graphhopper.routing.matrix.MatrixSnapResult;
 import com.graphhopper.routing.querygraph.QueryGraph;
 import com.graphhopper.routing.util.*;
 import com.graphhopper.storage.index.LocationIndex;
@@ -91,6 +92,46 @@ public class ViaRouting {
             throw new MultiplePointsNotFoundException(pointsNotFound);
 
         return snaps;
+    }
+
+    public static MatrixSnapResult lookupMatrixV2(EncodedValueLookup lookup, List<GHPoint> points, EdgeFilter snapFilter,
+                                                LocationIndex locationIndex, List<String> snapPreventions, List<String> pointHints,
+                                                DirectedEdgeFilter directedSnapFilter, List<Double> headings) {
+        if (points.size() < 1)
+            throw new IllegalArgumentException("At least 1 point have to be specified, but was:" + points.size());
+
+        final EnumEncodedValue<RoadClass> roadClassEnc = lookup.getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
+        final EnumEncodedValue<RoadEnvironment> roadEnvEnc = lookup.getEnumEncodedValue(RoadEnvironment.KEY, RoadEnvironment.class);
+        EdgeFilter strictEdgeFilter = snapPreventions.isEmpty()
+                ? snapFilter
+                : new SnapPreventionEdgeFilter(snapFilter, roadClassEnc, roadEnvEnc, snapPreventions);
+        List<Snap> snaps = new ArrayList<>(points.size());
+        IntArrayList pointsNotFound = new IntArrayList();
+        for (int placeIndex = 0; placeIndex < points.size(); placeIndex++) {
+            GHPoint point = points.get(placeIndex);
+            Snap snap = null;
+            if (placeIndex < headings.size() && !Double.isNaN(headings.get(placeIndex))) {
+                if (!pointHints.isEmpty() && !Helper.isEmpty(pointHints.get(placeIndex)))
+                    throw new IllegalArgumentException("Cannot specify heading and point_hint at the same time. " +
+                            "Make sure you specify either an empty point_hint (String) or a NaN heading (double) for point " + placeIndex);
+                snap = locationIndex.findClosest(point.lat, point.lon, new HeadingEdgeFilter(directedSnapFilter, headings.get(placeIndex), point));
+            } else if (!pointHints.isEmpty()) {
+                snap = locationIndex.findClosest(point.lat, point.lon, new NameSimilarityEdgeFilter(strictEdgeFilter,
+                        pointHints.get(placeIndex), point, 100));
+            } else if (!snapPreventions.isEmpty()) {
+                snap = locationIndex.findClosest(point.lat, point.lon, strictEdgeFilter);
+            }
+
+            if (snap == null || !snap.isValid())
+                snap = locationIndex.findClosest(point.lat, point.lon, snapFilter);
+            if (!snap.isValid())
+                pointsNotFound.add(placeIndex);
+
+            snaps.add(snap);
+        }
+
+        return new MatrixSnapResult(snaps,pointsNotFound);
+
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/matrix/CHMatrixCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/CHMatrixCalculator.java
@@ -21,11 +21,8 @@ package com.graphhopper.routing.matrix;
 import com.graphhopper.routing.AlgorithmOptions;
 import com.graphhopper.routing.matrix.algorithm.MatrixAlgorithm;
 import com.graphhopper.routing.matrix.algorithm.MatrixRoutingAlgorithmFactory;
-import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.StopWatch;
 import com.graphhopper.util.exceptions.MaximumNodesExceededException;
-
-import java.util.List;
 
 import static com.graphhopper.util.Parameters.Routing.MAX_VISITED_NODES;
 
@@ -42,33 +39,14 @@ public class CHMatrixCalculator implements MatrixCalculator {
     }
 
     @Override
-    public DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations) {
+    public DistanceMatrix calcMatrix(MatrixSnapResult origins, MatrixSnapResult destinations) {
         MatrixAlgorithm algo = createAlgo();
         return calcMatrix(origins, destinations, algo);
     }
 
-    @Override
-    public DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations) {
-        MatrixAlgorithm algo = createAlgo();
-        return calcMatrixV2(origins, destinations, algo);
-    }
-
-    private DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations, MatrixAlgorithm algo) {
+    private DistanceMatrix calcMatrix(MatrixSnapResult origins, MatrixSnapResult destinations, MatrixAlgorithm algo) {
         StopWatch sw = new StopWatch().start();
         DistanceMatrix matrix = algo.calcMatrix(origins, destinations);
-
-        int maxVisitedNodes = algoOpts.getHints().getInt(MAX_VISITED_NODES, Integer.MAX_VALUE);
-        if (algo.getVisitedNodes() >= maxVisitedNodes)
-            throw new MaximumNodesExceededException("No path found due to maximum nodes exceeded " + maxVisitedNodes, maxVisitedNodes);
-        visitedNodes = algo.getVisitedNodes();
-        debug += ", " + algo.getName() + "-routing:" + sw.stop().getMillis() + " ms";
-        System.out.println(debug);
-        return matrix;
-    }
-
-    private DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations, MatrixAlgorithm algo) {
-        StopWatch sw = new StopWatch().start();
-        DistanceMatrix matrix = algo.calcMatrixV2(origins, destinations);
 
         int maxVisitedNodes = algoOpts.getHints().getInt(MAX_VISITED_NODES, Integer.MAX_VALUE);
         if (algo.getVisitedNodes() >= maxVisitedNodes)

--- a/core/src/main/java/com/graphhopper/routing/matrix/CHMatrixCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/CHMatrixCalculator.java
@@ -47,9 +47,28 @@ public class CHMatrixCalculator implements MatrixCalculator {
         return calcMatrix(origins, destinations, algo);
     }
 
+    @Override
+    public DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations) {
+        MatrixAlgorithm algo = createAlgo();
+        return calcMatrixV2(origins, destinations, algo);
+    }
+
     private DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations, MatrixAlgorithm algo) {
         StopWatch sw = new StopWatch().start();
         DistanceMatrix matrix = algo.calcMatrix(origins, destinations);
+
+        int maxVisitedNodes = algoOpts.getHints().getInt(MAX_VISITED_NODES, Integer.MAX_VALUE);
+        if (algo.getVisitedNodes() >= maxVisitedNodes)
+            throw new MaximumNodesExceededException("No path found due to maximum nodes exceeded " + maxVisitedNodes, maxVisitedNodes);
+        visitedNodes = algo.getVisitedNodes();
+        debug += ", " + algo.getName() + "-routing:" + sw.stop().getMillis() + " ms";
+        System.out.println(debug);
+        return matrix;
+    }
+
+    private DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations, MatrixAlgorithm algo) {
+        StopWatch sw = new StopWatch().start();
+        DistanceMatrix matrix = algo.calcMatrixV2(origins, destinations);
 
         int maxVisitedNodes = algoOpts.getHints().getInt(MAX_VISITED_NODES, Integer.MAX_VALUE);
         if (algo.getVisitedNodes() >= maxVisitedNodes)

--- a/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
@@ -1,9 +1,7 @@
 package com.graphhopper.routing.matrix;
 
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
+import java.util.*;
 
 /**
  * Holds the resulting distance matrix for a given set of
@@ -16,6 +14,9 @@ import java.util.List;
  */
 public final class DistanceMatrix {
 
+    public static double DISTANCE_SNAP_ERROR_VALUE = -1;
+    public static long TIME_SNAP_ERROR_VALUE = -1;
+
     private final int numberOfOrigins;
     private final int numberOfDestinations;
 
@@ -23,8 +24,8 @@ public final class DistanceMatrix {
 
     private final long[][] times;
 
-    private List<Integer> snapOriginsErrors;
-    private List<Integer> snapDestinationErrors;
+    private Set<Integer> snapOriginsErrors;
+    private Set<Integer> snapDestinationErrors;
 
     public double[][] getDistances() {
         return distances;
@@ -47,9 +48,36 @@ public final class DistanceMatrix {
         distances = new double[numberOfOrigins][numberOfDestinations];
         times = new long[numberOfOrigins][numberOfDestinations];
 
-        this.snapOriginsErrors = new ArrayList<>();
-        this.snapDestinationErrors = new ArrayList<>();
+        this.snapOriginsErrors = new HashSet<>();
+        this.snapDestinationErrors = new HashSet<>();
 
+    }
+
+    public DistanceMatrix(int numberOfOrigins, int numberOfDestinations, HashSet<Integer> originsErrors, HashSet<Integer> destinationsErros) {
+        this.numberOfOrigins = numberOfOrigins;
+        this.numberOfDestinations = numberOfDestinations;
+
+        distances = new double[numberOfOrigins][numberOfDestinations];
+        times = new long[numberOfOrigins][numberOfDestinations];
+
+        this.snapOriginsErrors = originsErrors;
+        this.snapDestinationErrors = destinationsErros;
+
+    }
+
+    private void setSnapErrorValue(int origin, int destination){
+        distances[origin][destination] = DISTANCE_SNAP_ERROR_VALUE;
+        times[origin][destination] = TIME_SNAP_ERROR_VALUE;
+    }
+
+    public void setSnapErrorsValues(int originIdx){
+
+        boolean originError = snapOriginsErrors.contains(originIdx);
+        for(int i = 0; i < numberOfDestinations; i++){
+            if(originError || snapDestinationErrors.contains(i)){
+                setSnapErrorValue(originIdx,i);
+            }
+        }
     }
 
     /**

--- a/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
@@ -1,7 +1,10 @@
 package com.graphhopper.routing.matrix;
 
 
+import com.carrotsearch.hppc.IntArrayList;
+
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Holds the resulting distance matrix for a given set of
@@ -24,8 +27,8 @@ public final class DistanceMatrix {
 
     private final long[][] times;
 
-    private Set<Integer> snapOriginsErrors;
-    private Set<Integer> snapDestinationErrors;
+    private IntArrayList snapOriginsErrors;
+    private IntArrayList snapDestinationErrors;
 
     public double[][] getDistances() {
         return distances;
@@ -41,19 +44,8 @@ public final class DistanceMatrix {
      * @param numberOfOrigins      The number of origin points (rows)
      * @param numberOfDestinations The number of destination points (columns)
      */
-    public DistanceMatrix(int numberOfOrigins, int numberOfDestinations) {
-        this.numberOfOrigins = numberOfOrigins;
-        this.numberOfDestinations = numberOfDestinations;
 
-        distances = new double[numberOfOrigins][numberOfDestinations];
-        times = new long[numberOfOrigins][numberOfDestinations];
-
-        this.snapOriginsErrors = new HashSet<>();
-        this.snapDestinationErrors = new HashSet<>();
-
-    }
-
-    public DistanceMatrix(int numberOfOrigins, int numberOfDestinations, HashSet<Integer> originsErrors, HashSet<Integer> destinationsErros) {
+    public DistanceMatrix(int numberOfOrigins, int numberOfDestinations, IntArrayList originsErrors, IntArrayList destinationsErros) {
         this.numberOfOrigins = numberOfOrigins;
         this.numberOfDestinations = numberOfDestinations;
 
@@ -63,6 +55,10 @@ public final class DistanceMatrix {
         this.snapOriginsErrors = originsErrors;
         this.snapDestinationErrors = destinationsErros;
 
+        for(int i = 0; i < numberOfOrigins; i++){
+            setSnapErrorsValues(i);
+        }
+
     }
 
     private void setSnapErrorValue(int origin, int destination){
@@ -70,7 +66,7 @@ public final class DistanceMatrix {
         times[origin][destination] = TIME_SNAP_ERROR_VALUE;
     }
 
-    public void setSnapErrorsValues(int originIdx){
+    private void setSnapErrorsValues(int originIdx){
 
         boolean originError = snapOriginsErrors.contains(originIdx);
         for(int i = 0; i < numberOfDestinations; i++){

--- a/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
@@ -1,7 +1,9 @@
 package com.graphhopper.routing.matrix;
 
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * Holds the resulting distance matrix for a given set of
@@ -20,6 +22,9 @@ public final class DistanceMatrix {
     private final double[][] distances;
 
     private final long[][] times;
+
+    private List<Integer> snapOriginsErrors;
+    private List<Integer> snapDestinationErrors;
 
     public double[][] getDistances() {
         return distances;
@@ -41,6 +46,9 @@ public final class DistanceMatrix {
 
         distances = new double[numberOfOrigins][numberOfDestinations];
         times = new long[numberOfOrigins][numberOfDestinations];
+
+        this.snapOriginsErrors = new ArrayList<>();
+        this.snapDestinationErrors = new ArrayList<>();
 
     }
 

--- a/core/src/main/java/com/graphhopper/routing/matrix/GHMatrixRequest.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/GHMatrixRequest.java
@@ -18,6 +18,7 @@ public class GHMatrixRequest {
     private final List<GHPoint> origins = new ArrayList<>();
     private final List<GHPoint> destinations = new ArrayList<>();
     private final PMap hints = new PMap();
+    private boolean failFast = false;
 
     /**
      * One or more locations to use as the starting point for calculating travel distance and time.
@@ -67,5 +68,13 @@ public class GHMatrixRequest {
     public GHMatrixRequest putHint(String fieldName, Object value) {
         this.hints.putObject(fieldName, value);
         return this;
+    }
+
+    public boolean isFailFast() {
+        return failFast;
+    }
+
+    public void setFailFast(boolean failFast) {
+        this.failFast = failFast;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/matrix/MatrixCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/MatrixCalculator.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public interface MatrixCalculator {
     DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations);
+    DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations);
 
     String getDebugString();
 

--- a/core/src/main/java/com/graphhopper/routing/matrix/MatrixCalculator.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/MatrixCalculator.java
@@ -5,8 +5,7 @@ import com.graphhopper.storage.index.Snap;
 import java.util.List;
 
 public interface MatrixCalculator {
-    DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations);
-    DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations);
+    DistanceMatrix calcMatrix(MatrixSnapResult origins, MatrixSnapResult destinations);
 
     String getDebugString();
 

--- a/core/src/main/java/com/graphhopper/routing/matrix/MatrixSnapResult.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/MatrixSnapResult.java
@@ -1,0 +1,18 @@
+package com.graphhopper.routing.matrix;
+
+import com.carrotsearch.hppc.IntArrayList;
+import com.graphhopper.storage.index.Snap;
+
+import java.util.List;
+
+
+public class MatrixSnapResult {
+
+    List<Snap> snaps;
+    IntArrayList pointsNotFound = new IntArrayList();
+
+    public MatrixSnapResult(List<Snap> snaps, IntArrayList pointsNotFound) {
+        this.snaps = snaps;
+        this.pointsNotFound = pointsNotFound;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/matrix/MatrixSnapResult.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/MatrixSnapResult.java
@@ -11,8 +11,25 @@ public class MatrixSnapResult {
     List<Snap> snaps;
     IntArrayList pointsNotFound = new IntArrayList();
 
+    int size;
+
     public MatrixSnapResult(List<Snap> snaps, IntArrayList pointsNotFound) {
         this.snaps = snaps;
         this.pointsNotFound = pointsNotFound;
+        this.size = snaps.size() + pointsNotFound.size();
     }
+
+    public int size(){
+        return size;
+    }
+
+    public Snap get(int idx){
+        return this.snaps.get(idx);
+    }
+
+    public boolean isNotFound(int idx){
+        return this.pointsNotFound.contains(idx);
+    }
+
+
 }

--- a/core/src/main/java/com/graphhopper/routing/matrix/MatrixSnapResult.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/MatrixSnapResult.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class MatrixSnapResult {
 
     List<Snap> snaps;
-    IntArrayList pointsNotFound = new IntArrayList();
+    private IntArrayList pointsNotFound = new IntArrayList();
 
     int size;
 
@@ -28,8 +28,16 @@ public class MatrixSnapResult {
     }
 
     public boolean isNotFound(int idx){
-        return this.pointsNotFound.contains(idx);
+        return this.getPointsNotFound().contains(idx);
     }
 
+    public boolean isFound(int idx){
+        return !isNotFound(idx);
+    }
+
+
+    public IntArrayList getPointsNotFound() {
+        return pointsNotFound;
+    }
 
 }

--- a/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
@@ -54,6 +54,9 @@ public class RouterMatrix extends Router {
                 snapPreventions, pointHints, directedEdgeFilter, headings);
         MatrixSnapResult destinationsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getDestinations(), solver.createSnapFilter(), locationIndex,
                 snapPreventions, pointHints, directedEdgeFilter, headings);
+
+        List<Snap> allCorrectSnaps = new ArrayList<>(originsResult.snaps);
+        allCorrectSnaps.addAll(destinationsResult.snaps);
         //
 
         //TODO - Check the errors during snap
@@ -65,13 +68,13 @@ public class RouterMatrix extends Router {
 
         // (base) query graph used to resolve headings, curbsides etc. this is not necessarily the same thing as
         // the (possibly implementation specific) query graph used by PathCalculator
-        List<Snap> allSnaps = new ArrayList<>(origins);
-        allSnaps.addAll(destinations);
-        QueryGraph queryGraph = QueryGraph.create(graph, allSnaps);
-
+        //List<Snap> allSnaps = new ArrayList<>(origins);
+        //allSnaps.addAll(destinations);
+        QueryGraph queryGraph = QueryGraph.create(graph, allCorrectSnaps);
 
         MatrixCalculator matrixCalculator = solver.createMatrixCalculator(queryGraph);
         DistanceMatrix matrix = matrixCalculator.calcMatrix(origins, destinations);
+        DistanceMatrix matrixV2 = matrixCalculator.calcMatrixV2(originsResult, destinationsResult);
         ghMtxRsp.setMatrix(matrix);
 
         return ghMtxRsp;

--- a/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
@@ -49,7 +49,6 @@ public class RouterMatrix extends Router {
         List<String> pointHints = new ArrayList<>();
         List<String> snapPreventions = new ArrayList<>();
 
-        //
         MatrixSnapResult originsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getOrigins(), solver.createSnapFilter(), locationIndex,
                 snapPreventions, pointHints, directedEdgeFilter, headings);
         MatrixSnapResult destinationsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getDestinations(), solver.createSnapFilter(), locationIndex,
@@ -57,24 +56,11 @@ public class RouterMatrix extends Router {
 
         List<Snap> allCorrectSnaps = new ArrayList<>(originsResult.snaps);
         allCorrectSnaps.addAll(destinationsResult.snaps);
-        //
 
-        //TODO - Check the errors during snap
-        List<Snap> origins = ViaRouting.lookupMatrix(encodingManager, request.getOrigins(), solver.createSnapFilter(), locationIndex,
-                snapPreventions, pointHints, directedEdgeFilter, headings);
-
-        List<Snap> destinations = ViaRouting.lookupMatrix(encodingManager, request.getDestinations(), solver.createSnapFilter(), locationIndex,
-                snapPreventions, pointHints, directedEdgeFilter, headings);
-
-        // (base) query graph used to resolve headings, curbsides etc. this is not necessarily the same thing as
-        // the (possibly implementation specific) query graph used by PathCalculator
-        //List<Snap> allSnaps = new ArrayList<>(origins);
-        //allSnaps.addAll(destinations);
         QueryGraph queryGraph = QueryGraph.create(graph, allCorrectSnaps);
 
         MatrixCalculator matrixCalculator = solver.createMatrixCalculator(queryGraph);
-        DistanceMatrix matrix = matrixCalculator.calcMatrix(origins, destinations);
-        DistanceMatrix matrixV2 = matrixCalculator.calcMatrixV2(originsResult, destinationsResult);
+        DistanceMatrix matrix = matrixCalculator.calcMatrix(originsResult, destinationsResult);
         ghMtxRsp.setMatrix(matrix);
 
         return ghMtxRsp;

--- a/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
@@ -6,10 +6,6 @@ import com.graphhopper.routing.RouterConfig;
 import com.graphhopper.routing.ViaRouting;
 import com.graphhopper.routing.WeightingFactory;
 import com.graphhopper.routing.lm.LandmarkStorage;
-import com.graphhopper.routing.matrix.DistanceMatrix;
-import com.graphhopper.routing.matrix.GHMatrixRequest;
-import com.graphhopper.routing.matrix.GHMatrixResponse;
-import com.graphhopper.routing.matrix.MatrixCalculator;
 import com.graphhopper.routing.matrix.solver.CHMatrixSolver;
 import com.graphhopper.routing.matrix.solver.MatrixSolver;
 import com.graphhopper.routing.querygraph.QueryGraph;
@@ -49,9 +45,9 @@ public class RouterMatrix extends Router {
         List<String> pointHints = new ArrayList<>();
         List<String> snapPreventions = new ArrayList<>();
 
-        MatrixSnapResult originsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getOrigins(), solver.createSnapFilter(), locationIndex,
+        MatrixSnapResult originsResult = ViaRouting.lookupMatrix(request.isFailFast(), encodingManager, request.getOrigins(), solver.createSnapFilter(), locationIndex,
                 snapPreventions, pointHints, directedEdgeFilter, headings);
-        MatrixSnapResult destinationsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getDestinations(), solver.createSnapFilter(), locationIndex,
+        MatrixSnapResult destinationsResult = ViaRouting.lookupMatrix(request.isFailFast(), encodingManager, request.getDestinations(), solver.createSnapFilter(), locationIndex,
                 snapPreventions, pointHints, directedEdgeFilter, headings);
 
         List<Snap> allCorrectSnaps = new ArrayList<>(originsResult.snaps);

--- a/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/RouterMatrix.java
@@ -48,6 +48,15 @@ public class RouterMatrix extends Router {
         List<Double> headings = new ArrayList<>();
         List<String> pointHints = new ArrayList<>();
         List<String> snapPreventions = new ArrayList<>();
+
+        //
+        MatrixSnapResult originsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getOrigins(), solver.createSnapFilter(), locationIndex,
+                snapPreventions, pointHints, directedEdgeFilter, headings);
+        MatrixSnapResult destinationsResult = ViaRouting.lookupMatrixV2(encodingManager, request.getDestinations(), solver.createSnapFilter(), locationIndex,
+                snapPreventions, pointHints, directedEdgeFilter, headings);
+        //
+
+        //TODO - Check the errors during snap
         List<Snap> origins = ViaRouting.lookupMatrix(encodingManager, request.getOrigins(), solver.createSnapFilter(), locationIndex,
                 snapPreventions, pointHints, directedEdgeFilter, headings);
 

--- a/core/src/main/java/com/graphhopper/routing/matrix/algorithm/ManyToManySBI.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/algorithm/ManyToManySBI.java
@@ -87,19 +87,19 @@ public class ManyToManySBI implements MatrixAlgorithm {
     }
 
     @Override
-    public DistanceMatrix calcMatrixV2(MatrixSnapResult sources, MatrixSnapResult targets) {
+    public DistanceMatrix calcMatrix(MatrixSnapResult sources, MatrixSnapResult targets) {
 
         checkAlreadyRun();
 
         int numTargets = targets.size();
         int numSources = sources.size();
-        DistanceMatrix matrix = new DistanceMatrix(numSources, numTargets);
+        DistanceMatrix matrix = new DistanceMatrix(numSources, numTargets,sources.getPointsNotFound(),targets.getPointsNotFound());
 
         //Backward
 
         int idxTarget = 0;
         while (idxTarget < numTargets) {
-            if(!targets.isNotFound(idxTarget)){
+            if(targets.isFound(idxTarget)){
                 int closestNode = targets.get(idxTarget).getClosestNode();
                 findInitialNodesBackward(closestNode, idxTarget,null);
             }
@@ -117,12 +117,9 @@ public class ManyToManySBI implements MatrixAlgorithm {
         //Forward
         int idxSource = 0;
         while (idxSource < numSources) {
-            if(!targets.isNotFound(idxTarget)) {
+            if(sources.isFound(idxSource)) {
                 int closestNode = sources.get(idxSource).getClosestNode();
                 findInitialNodesForward(closestNode, idxSource, matrix);
-            }else{
-                //Si no se ha podido hacer snap del source
-                //Si de los targets no se ha podido hacer snap
             }
             idxSource++;
         }
@@ -131,45 +128,6 @@ public class ManyToManySBI implements MatrixAlgorithm {
 
         return matrix;
 
-    }
-
-    @Override
-    public DistanceMatrix calcMatrix(List<Snap> sources, List<Snap> targets) {
-
-        checkAlreadyRun();
-
-        int numTargets = targets.size();
-        int numSources = sources.size();
-        DistanceMatrix matrix = new DistanceMatrix(numSources, numTargets);
-
-        //Backward
-
-        int idxTarget = 0;
-        while (idxTarget < numTargets) {
-            int closestNode = targets.get(idxTarget).getClosestNode();
-            findInitialNodesBackward(closestNode, idxTarget,null);
-            idxTarget++;
-        }
-
-        backward();
-
-        //Reset collections for forward
-        this.heap.clear();
-        this.traversedNodes.clear();
-        this.downEdges.clear();
-        this.upEdges.clear();
-
-        //Forward
-        int idxSource = 0;
-        while (idxSource < numSources) {
-            int closestNode = sources.get(idxSource).getClosestNode();
-            findInitialNodesForward(closestNode, idxSource,matrix);
-            idxSource++;
-        }
-
-        forward(matrix);
-
-        return matrix;
     }
 
     protected void checkAlreadyRun() {

--- a/core/src/main/java/com/graphhopper/routing/matrix/algorithm/ManyToManySBI.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/algorithm/ManyToManySBI.java
@@ -87,6 +87,53 @@ public class ManyToManySBI implements MatrixAlgorithm {
     }
 
     @Override
+    public DistanceMatrix calcMatrixV2(MatrixSnapResult sources, MatrixSnapResult targets) {
+
+        checkAlreadyRun();
+
+        int numTargets = targets.size();
+        int numSources = sources.size();
+        DistanceMatrix matrix = new DistanceMatrix(numSources, numTargets);
+
+        //Backward
+
+        int idxTarget = 0;
+        while (idxTarget < numTargets) {
+            if(!targets.isNotFound(idxTarget)){
+                int closestNode = targets.get(idxTarget).getClosestNode();
+                findInitialNodesBackward(closestNode, idxTarget,null);
+            }
+            idxTarget++;
+        }
+
+        backward();
+
+        //Reset collections for forward
+        this.heap.clear();
+        this.traversedNodes.clear();
+        this.downEdges.clear();
+        this.upEdges.clear();
+
+        //Forward
+        int idxSource = 0;
+        while (idxSource < numSources) {
+            if(!targets.isNotFound(idxTarget)) {
+                int closestNode = sources.get(idxSource).getClosestNode();
+                findInitialNodesForward(closestNode, idxSource, matrix);
+            }else{
+                //Si no se ha podido hacer snap del source
+                //Si de los targets no se ha podido hacer snap
+            }
+            idxSource++;
+        }
+
+        forward(matrix);
+
+        return matrix;
+
+    }
+
+    @Override
     public DistanceMatrix calcMatrix(List<Snap> sources, List<Snap> targets) {
 
         checkAlreadyRun();

--- a/core/src/main/java/com/graphhopper/routing/matrix/algorithm/MatrixAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/algorithm/MatrixAlgorithm.java
@@ -1,6 +1,7 @@
 package com.graphhopper.routing.matrix.algorithm;
 
 import com.graphhopper.routing.matrix.DistanceMatrix;
+import com.graphhopper.routing.matrix.MatrixSnapResult;
 import com.graphhopper.storage.index.Snap;
 
 import java.util.List;
@@ -21,6 +22,8 @@ public interface MatrixAlgorithm {
      * @throws IllegalArgumentException Thrown when origin.size() < 1 or desitnations.size() < 1
      */
     DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations);
+
+    DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations);
 
     /**
      * Limit the search to numberOfNodes. See #681

--- a/core/src/main/java/com/graphhopper/routing/matrix/algorithm/MatrixAlgorithm.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/algorithm/MatrixAlgorithm.java
@@ -21,9 +21,8 @@ public interface MatrixAlgorithm {
      * @return Returns a row for each origin, with duration/distance info to each destination
      * @throws IllegalArgumentException Thrown when origin.size() < 1 or desitnations.size() < 1
      */
-    DistanceMatrix calcMatrix(List<Snap> origins, List<Snap> destinations);
 
-    DistanceMatrix calcMatrixV2(MatrixSnapResult origins, MatrixSnapResult destinations);
+    DistanceMatrix calcMatrix(MatrixSnapResult origins, MatrixSnapResult destinations);
 
     /**
      * Limit the search to numberOfNodes. See #681

--- a/core/src/test/java/com/graphhopper/GraphHopperMatrixTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperMatrixTest.java
@@ -19,12 +19,15 @@ package com.graphhopper;
 
 import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.Profile;
+import com.graphhopper.routing.MultiplePointsNotFoundException;
 import com.graphhopper.routing.matrix.DistanceMatrix;
 import com.graphhopper.routing.matrix.GHMatrixRequest;
 import com.graphhopper.util.Helper;
 import com.graphhopper.util.shapes.GHPoint;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 
@@ -36,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GraphHopperMatrixTest {
     private static final double DISTANCE_METERS_DELTA = 1d;
@@ -156,5 +160,111 @@ public class GraphHopperMatrixTest {
                 assertEquals(response.getBest().getTime(), time, TIME_MILLIS_DELTA, String.format("Unexpected time for points=%s", points));
             }
         }
+    }
+
+    @Test
+    public void testFailFast() {
+        MultiplePointsNotFoundException thrown = Assertions.assertThrows(MultiplePointsNotFoundException.class, () -> {
+            List<GHPoint> originPoints = new ArrayList<>();
+            originPoints.add(new GHPoint(42.50488142419136, 1.5239627305424333));
+            originPoints.add(new GHPoint(42.500908692810256, 1.0666521515059635));
+            List<GHPoint> destinationPoints = new ArrayList<>();
+            destinationPoints.add(new GHPoint(42.50272031776507, 1.5148522642488023));
+            destinationPoints.add(new GHPoint(42.50272031776507, 1.5148522642488023));
+
+            final MatrixText matrixText = new MatrixText();
+            matrixText.setDestinations(originPoints);
+            matrixText.setOrigins(destinationPoints);
+
+            Profile carProfile = new Profile("car");
+            carProfile.setTurnCosts(false);
+            CHProfile chCarProfile = new CHProfile("car");
+
+            List<Profile> profiles = new ArrayList<>();
+            profiles.add(carProfile);
+
+            List<CHProfile> chProfiles = new ArrayList<>();
+            chProfiles.add(chCarProfile);
+
+            GraphHopperConfig config = new GraphHopperConfig();
+            config.setProfiles(profiles);
+            config.setCHProfiles(chProfiles);
+
+
+            GraphHopper hopper = new GraphHopper()
+                    .setOSMFile(ANDORRA)
+                    .init(config)
+                    .setGraphHopperLocation(GH_LOCATION)
+                    .importOrLoad();
+
+            List<GHPoint> origins = matrixText.getOrigins();
+            List<GHPoint> destinations = matrixText.getDestinations();
+
+            GHMatrixRequest request = new GHMatrixRequest();
+            request.setFailFast(true);
+            request.setProfile("car");
+            request.setOrigins(origins);
+            request.setDestinations(destinations);
+
+            hopper.matrix(request).getMatrix();
+        });
+
+        Assertions.assertTrue(thrown.getPointsNotFound().size() > 0);
+    }
+
+    @Test
+    public void testFailFastDisabled() {
+        List<GHPoint> originPoints = new ArrayList<>();
+        originPoints.add(new GHPoint(42.50488142419136, 1.5239627305424333));
+        originPoints.add(new GHPoint(42.500908692810256, 1.0666521515059635)); // Point outside Andorra (Not found)
+        List<GHPoint> destinationPoints = new ArrayList<>();
+        destinationPoints.add(new GHPoint(42.50272031776507, 1.5148522642488023));
+        destinationPoints.add(new GHPoint(42.50272031776507, 1.5148522642488023));
+
+        final MatrixText matrixText = new MatrixText();
+        matrixText.setDestinations(originPoints);
+        matrixText.setOrigins(destinationPoints);
+
+        Profile carProfile = new Profile("car");
+        carProfile.setTurnCosts(false);
+        CHProfile chCarProfile = new CHProfile("car");
+
+        List<Profile> profiles = new ArrayList<>();
+        profiles.add(carProfile);
+
+        List<CHProfile> chProfiles = new ArrayList<>();
+        chProfiles.add(chCarProfile);
+
+        GraphHopperConfig config = new GraphHopperConfig();
+        config.setProfiles(profiles);
+        config.setCHProfiles(chProfiles);
+
+
+        GraphHopper hopper = new GraphHopper()
+                .setOSMFile(ANDORRA)
+                .init(config)
+                .setGraphHopperLocation(GH_LOCATION)
+                .importOrLoad();
+
+        List<GHPoint> origins = matrixText.getOrigins();
+        List<GHPoint> destinations = matrixText.getDestinations();
+
+        GHMatrixRequest request = new GHMatrixRequest();
+        request.setProfile("car");
+        request.setOrigins(origins);
+        request.setDestinations(destinations);
+
+        DistanceMatrix result = hopper.matrix(request).getMatrix();
+        System.out.println(result);
+        // Distance assertions
+        assertEquals(-1, result.getDistance(0, 1));
+        assertEquals(-1, result.getDistance(1, 1));
+        assertTrue(result.getDistance(0, 0) > 0);
+        assertTrue(result.getDistance(1, 0) > 0);
+        // Time assertions
+        assertEquals(-1.0, result.getTime(0, 1));
+        assertEquals(-1.0, result.getTime(1, 1));
+        assertTrue(result.getTime(0, 0) > 0);
+        assertTrue(result.getTime(1, 0) > 0);
     }
 }


### PR DESCRIPTION
## Jira Ticket
[Example-ticket-to-be-replaced](https://stuart-team.atlassian.net/browse/RSPS-1243)

## Implementation details
We added some logic, to take into account possible errors trying to snap (origin/destination points) to the closest edge. Instead of forcing the failure for the whole request, we contemplate the option to fail the computations affected by the erroneous points. So it will be up to the client to ignore the failed computations.

The failed computations are marked in the matrix results with -1.0 (time) and with -1 (distance).

In case you want to specify the `failFast` option to true, the system will fail with the exception `MultiplePointsNotFoundException` informing all the points not found in the request.

By default, the system `GHMatrixRequest` is configured with `failFast=false` as is the compatible behavior expected by `Solver`.

## Examples

```scala
GHMatrixRequest request = new GHMatrixRequest();
request.setFailFast(true);
request.setProfile("car");
request.setOrigins(origins);
request.setDestinations(destinations);
```

## Testing
Added unit tests (CI)
