### PR TITLE
RSPS-1249: Configure fail fast as false by default

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,3 +13,5 @@ mvn -B gitflow:release-finish
 So in develop, the version of the poms will be incremented automatically and master will contain the release branch merged and the tag created.
 
 For more information about how it works the plugin (options, parameters, etc) please refer to this [link](https://github.com/aleksandr-m/gitflow-maven-plugin).
+
+Remember to push the commits to `develop` and `master`

--- a/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
@@ -17,8 +17,8 @@ import java.util.function.Consumer;
  */
 public final class DistanceMatrix {
 
-    public static final double DISTANCE_SNAP_ERROR_VALUE = -1;
-    public static final long TIME_SNAP_ERROR_VALUE = -1;
+    public static final double DISTANCE_SNAP_ERROR_VALUE = Double.MAX_VALUE;
+    public static final long TIME_SNAP_ERROR_VALUE = Long.MAX_VALUE;
 
     private final int numberOfOrigins;
     private final int numberOfDestinations;

--- a/core/src/main/java/com/graphhopper/routing/matrix/GHMatrixRequest.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/GHMatrixRequest.java
@@ -18,7 +18,7 @@ public class GHMatrixRequest {
     private final List<GHPoint> origins = new ArrayList<>();
     private final List<GHPoint> destinations = new ArrayList<>();
     private final PMap hints = new PMap();
-    private boolean failFast = false;
+    private boolean failFast = true;
 
     /**
      * One or more locations to use as the starting point for calculating travel distance and time.

--- a/core/src/test/java/com/graphhopper/GraphHopperMatrixTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperMatrixTest.java
@@ -202,7 +202,6 @@ public class GraphHopperMatrixTest {
         List<GHPoint> destinations = matrixText.getDestinations();
 
         GHMatrixRequest request = new GHMatrixRequest();
-        request.setFailFast(true);
         request.setProfile("car");
         request.setOrigins(origins);
         request.setDestinations(destinations);
@@ -253,6 +252,7 @@ public class GraphHopperMatrixTest {
 
         GHMatrixRequest request = new GHMatrixRequest();
         request.setProfile("car");
+        request.setFailFast(false);
         request.setOrigins(origins);
         request.setDestinations(destinations);
 


### PR DESCRIPTION
## Jira Ticket
[RSPS-1249](https://stuart-team.atlassian.net/browse/RSPS-1249)

## Implementation details
This PR configures fail fast as true by default, and returns Long.MAX_VALUE/Double.MAX_VALUE when fail fast is false and some routes fail

## Examples
NA

## Testing
CI


[RSPS-1249]: https://stuart-team.atlassian.net/browse/RSPS-1249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ