### PR TITLE
[RSPS-1284] - Set max returning values for matrix to 1e7

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
+++ b/core/src/main/java/com/graphhopper/routing/matrix/DistanceMatrix.java
@@ -17,8 +17,8 @@ import java.util.function.Consumer;
  */
 public final class DistanceMatrix {
 
-    public static final double DISTANCE_SNAP_ERROR_VALUE = Double.MAX_VALUE;
-    public static final long TIME_SNAP_ERROR_VALUE = Long.MAX_VALUE;
+    public static final double DISTANCE_SNAP_ERROR_VALUE = 1e7;
+    public static final long TIME_SNAP_ERROR_VALUE = 10000000;
 
     private final int numberOfOrigins;
     private final int numberOfDestinations;


### PR DESCRIPTION
## Jira Ticket
[RSPS-1284](https://stuart-team.atlassian.net/browse/RSPS-1284)

## Implementation details
When cannot snap return as max value 1e7 like STM



[RSPS-1284]: https://stuart-team.atlassian.net/browse/RSPS-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ