### PR TITLE
RSPS-1714:  Support toll overrides for car,motorcycle, bicycle and foot

### DIFF
--- a/core/src/main/java/com/graphhopper/routing/ev/TollBicycle.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/TollBicycle.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+
+public enum TollBicycle {
+    MISSING("missing"), YES("yes"), NO("no");
+
+    public static final String KEY = "toll_bicycle";
+
+    private final String name;
+
+    TollBicycle(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/TollCar.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/TollCar.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+
+public enum TollCar {
+    MISSING("missing"), YES("yes"), NO("no");
+
+    public static final String KEY = "toll_car";
+
+    private final String name;
+
+    TollCar(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/TollFoot.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/TollFoot.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+
+public enum TollFoot {
+    MISSING("missing"), YES("yes"), NO("no");
+
+    public static final String KEY = "toll_foot";
+
+    private final String name;
+
+    TollFoot(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/ev/TollMotorcycle.java
+++ b/core/src/main/java/com/graphhopper/routing/ev/TollMotorcycle.java
@@ -1,0 +1,36 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.ev;
+
+
+public enum TollMotorcycle {
+    MISSING("missing"), YES("yes"), NO("no");
+
+    public static final String KEY = "toll_motorcycle";
+
+    private final String name;
+
+    TollMotorcycle(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -80,12 +80,23 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMFootwayParser(lookup.getEnumEncodedValue(Footway.KEY, Footway.class));
         else if (name.equals(Country.KEY))
             return new CountryParser(lookup.getEnumEncodedValue(Country.KEY, Country.class));
+<<<<<<< Updated upstream
         else if (name.equals(State.KEY))
             return new StateParser(lookup.getEnumEncodedValue(State.KEY, State.class));
         else if (name.equals(Crossing.KEY))
             return new OSMCrossingParser(lookup.getEnumEncodedValue(Crossing.KEY, Crossing.class));
         else if (name.equals(FerrySpeed.KEY))
             return new FerrySpeedCalculator(lookup.getDecimalEncodedValue(FerrySpeed.KEY));
+=======
+        else if (name.equals(TollMotorcycle.KEY))
+            return new OSMTollMotorcycleParser(lookup.getEnumEncodedValue(TollMotorcycle.KEY, TollMotorcycle.class));
+        else if (name.equals(TollBicycle.KEY))
+            return new OSMTollBicycleParser(lookup.getEnumEncodedValue(TollBicycle.KEY, TollBicycle.class));
+        else if (name.equals(TollCar.KEY))
+            return new OSMTollCarParser(lookup.getEnumEncodedValue(TollCar.KEY, TollCar.class));
+        else if (name.equals(TollFoot.KEY))
+            return new OSMTollFootParser(lookup.getEnumEncodedValue(TollFoot.KEY, TollFoot.class));
+>>>>>>> Stashed changes
         return null;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/DefaultTagParserFactory.java
@@ -80,14 +80,12 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMFootwayParser(lookup.getEnumEncodedValue(Footway.KEY, Footway.class));
         else if (name.equals(Country.KEY))
             return new CountryParser(lookup.getEnumEncodedValue(Country.KEY, Country.class));
-<<<<<<< Updated upstream
         else if (name.equals(State.KEY))
             return new StateParser(lookup.getEnumEncodedValue(State.KEY, State.class));
         else if (name.equals(Crossing.KEY))
             return new OSMCrossingParser(lookup.getEnumEncodedValue(Crossing.KEY, Crossing.class));
         else if (name.equals(FerrySpeed.KEY))
             return new FerrySpeedCalculator(lookup.getDecimalEncodedValue(FerrySpeed.KEY));
-=======
         else if (name.equals(TollMotorcycle.KEY))
             return new OSMTollMotorcycleParser(lookup.getEnumEncodedValue(TollMotorcycle.KEY, TollMotorcycle.class));
         else if (name.equals(TollBicycle.KEY))
@@ -96,7 +94,6 @@ public class DefaultTagParserFactory implements TagParserFactory {
             return new OSMTollCarParser(lookup.getEnumEncodedValue(TollCar.KEY, TollCar.class));
         else if (name.equals(TollFoot.KEY))
             return new OSMTollFootParser(lookup.getEnumEncodedValue(TollFoot.KEY, TollFoot.class));
->>>>>>> Stashed changes
         return null;
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParser.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.TollBicycle;
 import com.graphhopper.storage.IntsRef;
@@ -31,7 +32,7 @@ public class OSMTollBicycleParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay readerWay, IntsRef relationFlags) {
         TollBicycle toll;
         if (readerWay.hasTag("toll:bicycle", "yes")) {
             toll = TollBicycle.YES;
@@ -41,8 +42,6 @@ public class OSMTollBicycleParser implements TagParser {
             toll = TollBicycle.MISSING;
         }
 
-        tollEnc.setEnum(false, edgeFlags, toll);
-
-        return edgeFlags;
+        tollEnc.setEnum(false, edgeId, edgeIntAccess, toll);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParser.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollBicycle;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMTollBicycleParser implements TagParser {
+
+    private final EnumEncodedValue<TollBicycle> tollEnc;
+
+    public OSMTollBicycleParser(EnumEncodedValue<TollBicycle> tollEnc) {
+        this.tollEnc = tollEnc;
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+        TollBicycle toll;
+        if (readerWay.hasTag("toll:bicycle", "yes")) {
+            toll = TollBicycle.YES;
+        } else if (readerWay.hasTag("toll:bicycle", "no")) {
+            toll = TollBicycle.NO;
+        } else {
+            toll = TollBicycle.MISSING;
+        }
+
+        tollEnc.setEnum(false, edgeFlags, toll);
+
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollCarParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollCarParser.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.TollCar;
 import com.graphhopper.storage.IntsRef;
@@ -31,7 +32,7 @@ public class OSMTollCarParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay readerWay, IntsRef relationFlags) {
         TollCar toll;
         if (readerWay.hasTag("toll:car", "yes")) {
             toll = TollCar.YES;
@@ -41,8 +42,6 @@ public class OSMTollCarParser implements TagParser {
             toll = TollCar.MISSING;
         }
 
-        tollEnc.setEnum(false, edgeFlags, toll);
-
-        return edgeFlags;
+        tollEnc.setEnum(false, edgeId, edgeIntAccess, toll);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollCarParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollCarParser.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollCar;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMTollCarParser implements TagParser {
+
+    private final EnumEncodedValue<TollCar> tollEnc;
+
+    public OSMTollCarParser(EnumEncodedValue<TollCar> tollEnc) {
+        this.tollEnc = tollEnc;
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+        TollCar toll;
+        if (readerWay.hasTag("toll:car", "yes")) {
+            toll = TollCar.YES;
+        } else if (readerWay.hasTag("toll:car", "no")) {
+            toll = TollCar.NO;
+        } else {
+            toll = TollCar.MISSING;
+        }
+
+        tollEnc.setEnum(false, edgeFlags, toll);
+
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollFootParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollFootParser.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollFoot;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMTollFootParser implements TagParser {
+
+    private final EnumEncodedValue<TollFoot> tollEnc;
+
+    public OSMTollFootParser(EnumEncodedValue<TollFoot> tollEnc) {
+        this.tollEnc = tollEnc;
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+        TollFoot toll;
+        if (readerWay.hasTag("toll:foot", "yes")) {
+            toll = TollFoot.YES;
+        } else if (readerWay.hasTag("toll:foot", "no")) {
+            toll = TollFoot.NO;
+        } else {
+            toll = TollFoot.MISSING;
+        }
+
+        tollEnc.setEnum(false, edgeFlags, toll);
+
+        return edgeFlags;
+    }
+}

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollFootParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollFootParser.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.TollFoot;
 import com.graphhopper.storage.IntsRef;
@@ -31,7 +32,7 @@ public class OSMTollFootParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay readerWay, IntsRef relationFlags) {
         TollFoot toll;
         if (readerWay.hasTag("toll:foot", "yes")) {
             toll = TollFoot.YES;
@@ -41,8 +42,6 @@ public class OSMTollFootParser implements TagParser {
             toll = TollFoot.MISSING;
         }
 
-        tollEnc.setEnum(false, edgeFlags, toll);
-
-        return edgeFlags;
+        tollEnc.setEnum(false, edgeId, edgeIntAccess, toll);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParser.java
@@ -18,6 +18,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EdgeIntAccess;
 import com.graphhopper.routing.ev.EnumEncodedValue;
 import com.graphhopper.routing.ev.TollMotorcycle;
 import com.graphhopper.storage.IntsRef;
@@ -31,7 +32,7 @@ public class OSMTollMotorcycleParser implements TagParser {
     }
 
     @Override
-    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+    public void handleWayTags(int edgeId, EdgeIntAccess edgeIntAccess, ReaderWay readerWay, IntsRef relationFlags) {
         TollMotorcycle toll;
         if (readerWay.hasTag("toll:motorcycle", "yes")) {
             toll = TollMotorcycle.YES;
@@ -41,8 +42,6 @@ public class OSMTollMotorcycleParser implements TagParser {
             toll = TollMotorcycle.MISSING;
         }
 
-        tollEnc.setEnum(false, edgeFlags, toll);
-
-        return edgeFlags;
+        tollEnc.setEnum(false, edgeId, edgeIntAccess, toll);
     }
 }

--- a/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParser.java
+++ b/core/src/main/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParser.java
@@ -1,0 +1,48 @@
+/*
+ *  Licensed to GraphHopper GmbH under one or more contributor
+ *  license agreements. See the NOTICE file distributed with this work for
+ *  additional information regarding copyright ownership.
+ *
+ *  GraphHopper GmbH licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except in
+ *  compliance with the License. You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollMotorcycle;
+import com.graphhopper.storage.IntsRef;
+
+public class OSMTollMotorcycleParser implements TagParser {
+
+    private final EnumEncodedValue<TollMotorcycle> tollEnc;
+
+    public OSMTollMotorcycleParser(EnumEncodedValue<TollMotorcycle> tollEnc) {
+        this.tollEnc = tollEnc;
+    }
+
+    @Override
+    public IntsRef handleWayTags(IntsRef edgeFlags, ReaderWay readerWay, IntsRef relationFlags) {
+        TollMotorcycle toll;
+        if (readerWay.hasTag("toll:motorcycle", "yes")) {
+            toll = TollMotorcycle.YES;
+        } else if (readerWay.hasTag("toll:motorcycle", "no")) {
+            toll = TollMotorcycle.NO;
+        } else {
+            toll = TollMotorcycle.MISSING;
+        }
+
+        tollEnc.setEnum(false, edgeFlags, toll);
+
+        return edgeFlags;
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParserTest.java
@@ -1,0 +1,45 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollBicycle;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OSMTollBicycleParserTest {
+    private EnumEncodedValue<TollBicycle> tollEnc;
+    private OSMTollBicycleParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        tollEnc = new EnumEncodedValue<>(TollBicycle.KEY, TollBicycle.class);
+        tollEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMTollBicycleParser(tollEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        IntsRef intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollBicycle.MISSING, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:bicycle", "yes");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollBicycle.YES, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:bicycle", "no");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollBicycle.NO, tollEnc.getEnum(false, intsRef));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollBicycleParserTest.java
@@ -1,9 +1,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.TollBicycle;
+import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,24 +20,39 @@ public class OSMTollBicycleParserTest {
     }
 
     @Test
-    public void testSimpleTags() {
+    public void testTollBicycleYes() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef relFlags = new IntsRef(2);
-        IntsRef intsRef = new IntsRef(1);
-        readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollBicycle.MISSING, tollEnc.getEnum(false, intsRef));
-
-        intsRef = new IntsRef(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:bicycle", "yes");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollBicycle.YES, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollBicycle.YES, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
 
-        intsRef = new IntsRef(1);
+    @Test
+    public void testTollBicycleNo() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:bicycle", "no");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollBicycle.NO, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollBicycle.NO, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    public void testTollBicycleMissing() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollBicycle.MISSING, tollEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollCarParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollCarParserTest.java
@@ -1,9 +1,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.TollCar;
+import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,24 +20,37 @@ public class OSMTollCarParserTest {
     }
 
     @Test
-    public void testSimpleTags() {
+    public void testTollCarYes() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef relFlags = new IntsRef(2);
-        IntsRef intsRef = new IntsRef(1);
-        readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollCar.MISSING, tollEnc.getEnum(false, intsRef));
-
-        intsRef = new IntsRef(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:car", "yes");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollCar.YES, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollCar.YES, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
 
-        intsRef = new IntsRef(1);
+    @Test
+    public void testTollCarNo() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:car", "no");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollCar.NO, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollCar.NO, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    public void testTollCarMissing() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollCar.MISSING, tollEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollCarParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollCarParserTest.java
@@ -1,0 +1,45 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollCar;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OSMTollCarParserTest {
+    private EnumEncodedValue<TollCar> tollEnc;
+    private OSMTollCarParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        tollEnc = new EnumEncodedValue<>(TollCar.KEY, TollCar.class);
+        tollEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMTollCarParser(tollEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        IntsRef intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollCar.MISSING, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:car", "yes");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollCar.YES, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:car", "no");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollCar.NO, tollEnc.getEnum(false, intsRef));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollFootParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollFootParserTest.java
@@ -1,0 +1,45 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollFoot;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OSMTollFootParserTest {
+    private EnumEncodedValue<TollFoot> tollEnc;
+    private OSMTollFootParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        tollEnc = new EnumEncodedValue<>(TollFoot.KEY, TollFoot.class);
+        tollEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMTollFootParser(tollEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        IntsRef intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollFoot.MISSING, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:foot", "yes");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollFoot.YES, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:foot", "no");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollFoot.NO, tollEnc.getEnum(false, intsRef));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollFootParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollFootParserTest.java
@@ -1,9 +1,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.TollFoot;
+import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,24 +20,37 @@ public class OSMTollFootParserTest {
     }
 
     @Test
-    public void testSimpleTags() {
+    public void testTollFootYes() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef relFlags = new IntsRef(2);
-        IntsRef intsRef = new IntsRef(1);
-        readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollFoot.MISSING, tollEnc.getEnum(false, intsRef));
-
-        intsRef = new IntsRef(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:foot", "yes");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollFoot.YES, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollFoot.YES, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
 
-        intsRef = new IntsRef(1);
+    @Test
+    public void testTollFootNo() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:foot", "no");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollFoot.NO, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollFoot.NO, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    public void testTollFootMissing() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollFoot.MISSING, tollEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParserTest.java
@@ -1,0 +1,45 @@
+package com.graphhopper.routing.util.parsers;
+
+import com.graphhopper.reader.ReaderWay;
+import com.graphhopper.routing.ev.EncodedValue;
+import com.graphhopper.routing.ev.EnumEncodedValue;
+import com.graphhopper.routing.ev.TollMotorcycle;
+import com.graphhopper.storage.IntsRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class OSMTollMotorcycleParserTest {
+    private EnumEncodedValue<TollMotorcycle> tollEnc;
+    private OSMTollMotorcycleParser parser;
+
+    @BeforeEach
+    public void setUp() {
+        tollEnc = new EnumEncodedValue<>(TollMotorcycle.KEY, TollMotorcycle.class);
+        tollEnc.init(new EncodedValue.InitializerConfig());
+        parser = new OSMTollMotorcycleParser(tollEnc);
+    }
+
+    @Test
+    public void testSimpleTags() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        IntsRef intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollMotorcycle.MISSING, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:motorcycle", "yes");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollMotorcycle.YES, tollEnc.getEnum(false, intsRef));
+
+        intsRef = new IntsRef(1);
+        readerWay.setTag("highway", "primary");
+        readerWay.setTag("toll:motorcycle", "no");
+        parser.handleWayTags(intsRef, readerWay, relFlags);
+        assertEquals(TollMotorcycle.NO, tollEnc.getEnum(false, intsRef));
+    }
+}

--- a/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParserTest.java
+++ b/core/src/test/java/com/graphhopper/routing/util/parsers/OSMTollMotorcycleParserTest.java
@@ -1,9 +1,7 @@
 package com.graphhopper.routing.util.parsers;
 
 import com.graphhopper.reader.ReaderWay;
-import com.graphhopper.routing.ev.EncodedValue;
-import com.graphhopper.routing.ev.EnumEncodedValue;
-import com.graphhopper.routing.ev.TollMotorcycle;
+import com.graphhopper.routing.ev.*;
 import com.graphhopper.storage.IntsRef;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,24 +20,37 @@ public class OSMTollMotorcycleParserTest {
     }
 
     @Test
-    public void testSimpleTags() {
+    public void testTollMotorcycleYes() {
         ReaderWay readerWay = new ReaderWay(1);
         IntsRef relFlags = new IntsRef(2);
-        IntsRef intsRef = new IntsRef(1);
-        readerWay.setTag("highway", "primary");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollMotorcycle.MISSING, tollEnc.getEnum(false, intsRef));
-
-        intsRef = new IntsRef(1);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:motorcycle", "yes");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollMotorcycle.YES, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollMotorcycle.YES, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
 
-        intsRef = new IntsRef(1);
+    @Test
+    public void testTollMotorcycleNo() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
         readerWay.setTag("highway", "primary");
         readerWay.setTag("toll:motorcycle", "no");
-        parser.handleWayTags(intsRef, readerWay, relFlags);
-        assertEquals(TollMotorcycle.NO, tollEnc.getEnum(false, intsRef));
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollMotorcycle.NO, tollEnc.getEnum(false, edgeId, edgeIntAccess));
+    }
+
+    @Test
+    public void testTollMotorcycleMissing() {
+        ReaderWay readerWay = new ReaderWay(1);
+        IntsRef relFlags = new IntsRef(2);
+        EdgeIntAccess edgeIntAccess = new ArrayEdgeIntAccess(1);
+        int edgeId = 0;
+        readerWay.setTag("highway", "primary");
+        parser.handleWayTags(edgeId, edgeIntAccess, readerWay, relFlags);
+        assertEquals(TollMotorcycle.MISSING, tollEnc.getEnum(false, edgeId, edgeIntAccess));
     }
 }

--- a/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
+++ b/core/src/test/java/com/graphhopper/routing/weighting/custom/CustomWeightingTest.java
@@ -41,17 +41,11 @@ class CustomWeightingTest {
         accessEnc = VehicleAccess.create("car");
         avSpeedEnc = VehicleSpeed.create("car", 5, 5, true);
         encodingManager = new EncodingManager.Builder().add(accessEnc).add(avSpeedEnc)
-<<<<<<< Updated upstream
                 .add(Toll.create())
                 .add(Hazmat.create())
                 .add(RouteNetwork.create(BikeNetwork.KEY))
                 .addTurnCostEncodedValue(turnRestrictionEnc)
-=======
-                .add(new EnumEncodedValue<>(Toll.KEY, Toll.class))
-                .add(new EnumEncodedValue<>(Hazmat.KEY, Hazmat.class))
-                .add(new EnumEncodedValue<>(BikeNetwork.KEY, RouteNetwork.class))
                 .add(new EnumEncodedValue<>(TollCar.KEY, TollCar.class))
->>>>>>> Stashed changes
                 .build();
         maxSpeedEnc = encodingManager.getDecimalEncodedValue(MaxSpeed.KEY);
         roadClassEnc = encodingManager.getEnumEncodedValue(KEY, RoadClass.class);
@@ -382,9 +376,9 @@ class CustomWeightingTest {
         vehicleModel.addToPriority(If("toll == NO && toll_car == YES", MULTIPLY, "0.0"));
         vehicleModel.addToPriority(If("toll == ALL && toll_car != NO", MULTIPLY, "0.0"));
 
-        assertEquals(1.6, createWeighting(vehicleModel).calcEdgeWeight(withTollButCarNo, false), 0.01);
-        assertEquals(1.42, createWeighting(vehicleModel).calcEdgeWeight(withNoTollButCarMissing, false), 0.01);
-        assertEquals(1.42, createWeighting(vehicleModel).calcEdgeWeight(withNoTollButCarNo, false), 0.01);
+        assertEquals(0.9, createWeighting(vehicleModel).calcEdgeWeight(withTollButCarNo, false), 0.01);
+        assertEquals(0.72, createWeighting(vehicleModel).calcEdgeWeight(withNoTollButCarMissing, false), 0.01);
+        assertEquals(0.72, createWeighting(vehicleModel).calcEdgeWeight(withNoTollButCarNo, false), 0.01);
         assertTrue(Double.isInfinite(createWeighting(vehicleModel).calcEdgeWeight(withNoTollButCarYes, false)));
         assertTrue(Double.isInfinite(createWeighting(vehicleModel).calcEdgeWeight(withTollButCarMissing, false)));
         assertTrue(Double.isInfinite(createWeighting(vehicleModel).calcEdgeWeight(withTollButCarYes, false)));


### PR DESCRIPTION
## Jira Ticket
[RSPS-1714](https://stuart-team.atlassian.net/browse/RSPS-1714)

## Implementation details
This PR includes new encoders too manage toll overrides metadata. It adds support for `car,motorcycle,foot and bicycle`.
With this new approach, you will have available data in your custom models related to General Toll rules and also related to Specific Toll rules.

## Examples
With this new feature you will be able to manage toll override information in this way from you custom model

```json
"priority": [
    {
      "if": "toll == ALL && toll_car != NO",
      "multiply_by": 0.0
    },
    {
      "if": "toll_car == YES",
      "multiply_by": 0.0
    }
  ],
```

To make this new flag encoder accessible you need to enable it in your `config.yml`

```yaml
graphhopper:
  datareader.file: ""
  graph.location: ""
  graph.elevation.provider: "srtm"
  prepare.min_network_size: 700
  routing.non_ch.max_waypoint_distance: 1000000
  graph.dataaccess: "RAM_STORE"
  graph.encoded_values: "track_type,toll,toll_car"
  graph.flag_encoders: car|turn_costs=true
```

## Testing
If necessary add description on what is tested locally and all the types of tests you added.
