### PR TITLE
[RSPS-2011]:  Fix speed too high bug

### DIFF
--- a/client-hc/pom.xml
+++ b/client-hc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>  
     
     <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
+++ b/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
@@ -39,6 +39,10 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
         long endTime = System.nanoTime();
         long elapsed = (endTime - startTime);
         long durationInMillis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+
+        //Save Encoding Manager Into Properties to have Max Speed in place after setting the new speeds
+        this.writeEncodingManagerToProperties();
+
         logger.info("End Custom Speeds Provider : Graph processed in " + durationInMillis);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -71,7 +71,7 @@ public class CustomModelParser {
                                                   EncodedValueLookup lookup, TurnCostProvider turnCostProvider, CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-        double maxSpeed = speedEnc.getMaxStorableDecimal();
+        double maxSpeed = speedEnc.getMaxOrMaxStorableDecimal();
         CustomWeighting.Parameters parameters = createWeightingParameters(customModel, lookup, speedEnc, maxSpeed, priorityEnc);
         return new CustomWeighting(accessEnc, speedEnc, turnCostProvider, parameters);
     }

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -71,7 +71,7 @@ public class CustomModelParser {
                                                   EncodedValueLookup lookup, TurnCostProvider turnCostProvider, CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-        double maxSpeed = speedEnc.getMaxOrMaxStorableDecimal();
+        double maxSpeed = speedEnc.getMaxStorableDecimal();
         CustomWeighting.Parameters parameters = createWeightingParameters(customModel, lookup, speedEnc, maxSpeed, priorityEnc);
         return new CustomWeighting(accessEnc, speedEnc, turnCostProvider, parameters);
     }

--- a/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
@@ -55,21 +55,22 @@ public class GraphHopperCustomSpeedsTest {
         Helper.removeDir(new File(GH_LOCATION_CUSTOM_SPEEDS));
     }
 
-    class CustomWaySpeedProvider implements WaySpeedsProvider {
-
-        @Override
-        public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
-            return Optional.of(new SpeedKmByHour(10.10));
-        }
-
-        @Override
-        public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
-            return Optional.of(new SpeedKmByHour(10.1));
-        }
-    }
-
     @Test
     public void testDynamicSpeedProvider() {
+
+        class CustomWaySpeedProvider implements WaySpeedsProvider {
+
+            @Override
+            public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
+                return Optional.of(new SpeedKmByHour(10.10));
+            }
+
+            @Override
+            public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
+                return Optional.of(new SpeedKmByHour(10.1));
+            }
+        }
+
         final String bikeProfile = "bike_profile";
         final String carProfile = "car_profile";
         List<Profile> profiles = asList(
@@ -101,34 +102,167 @@ public class GraphHopperCustomSpeedsTest {
         hopper.importOrLoad();
         hopperCustomSpeeds.importOrLoad();
 
-        GHResponse rsp = hopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setProfile(carProfile));
+        GHRequest request = new GHRequest(43.73005, 7.415707, 43.741522, 7.42826);
+
+        GHResponse rsp = hopper.route(request.setProfile(carProfile));
         ResponsePath res = rsp.getBest();
         assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
         assertEquals(205, res.getTime() / 1000f, 1);
         assertEquals(2837, res.getDistance(), 1);
 
-        GHResponse rspSpeeds = hopperCustomSpeeds.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setProfile(carProfile));
+        GHResponse rspSpeeds = hopperCustomSpeeds.route(request.setProfile(carProfile));
         ResponsePath resSpeeds = rspSpeeds.getBest();
         assertFalse(rspSpeeds.hasErrors(), rspSpeeds.getErrors().toString());
         assertEquals(893, resSpeeds.getTime() / 1000f, 1);
         assertEquals(2481, resSpeeds.getDistance(), 1);
 
 
-        GHResponse rspBike = hopper.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setProfile(bikeProfile));
+        GHResponse rspBike = hopper.route(request.setProfile(bikeProfile));
         ResponsePath resBike = rspBike.getBest();
         assertFalse(rspBike.hasErrors(), rspBike.getErrors().toString());
         assertEquals(536, resBike.getTime() / 1000f, 1);
         assertEquals(2521, resBike.getDistance(), 1);
 
-        GHResponse rspBikeSpeeds = hopperCustomSpeeds.route(new GHRequest(43.73005, 7.415707, 43.741522, 7.42826)
-                .setProfile(bikeProfile));
+        GHResponse rspBikeSpeeds = hopperCustomSpeeds.route(request.setProfile(bikeProfile));
         ResponsePath resBikeSpeeds = rspBikeSpeeds.getBest();
         assertFalse(rspBikeSpeeds.hasErrors(), rspBikeSpeeds.getErrors().toString());
         assertEquals(834, resBikeSpeeds.getTime() / 1000f, 1);
         assertEquals(2318, resBikeSpeeds.getDistance(), 1);
+
+    }
+
+    @Test
+    public void testDynamicSpeedProviderDiscardCustomSpeedIfHigherThanMaxSpeed() {
+
+        class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
+
+            @Override
+            public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
+                return Optional.of(new SpeedKmByHour(100));
+            }
+
+            @Override
+            public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
+                return Optional.of(new SpeedKmByHour(80.1));
+            }
+        }
+
+        final String carProfile = "car_profile";
+
+        List<Profile> profiles = asList(new Profile(carProfile).setVehicle("car"));
+
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setOSMFile(MONACO).
+                setProfiles(profiles).
+                setStoreOnFlush(true);
+        hopper.getCHPreparationHandler().setCHProfiles(
+                new CHProfile(carProfile)
+        );
+
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
+                setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
+                setOSMFile(MONACO).
+                setProfiles(profiles).
+                setStoreOnFlush(true)
+                .setEncodedValuesString("roundabout, road_class, road_class_link, road_environment, max_speed, road_access, ferry_speed, bike_network, get_off_bike, smoothness, osm_way_id");
+        hopperCustomSpeeds.getCHPreparationHandler().setCHProfiles(
+                new CHProfile(carProfile)
+        );
+
+        hopper.importOrLoad();
+        hopperCustomSpeeds.importOrLoad();
+
+        // requests uses osm way 166009792 (secondary road, that has max speed = 50km)
+        GHRequest request = new GHRequest(43.73887, 7.42074, 43.73992, 7.42386);
+
+        GHResponse rsp = hopper.route(request.setProfile(carProfile));
+        ResponsePath res = rsp.getBest();
+        assertFalse(rsp.hasErrors(), rsp.getErrors().toString());
+        assertEquals(21, res.getTime() / 1000f, 1); // 47kmh = 13.2m/s
+        assertEquals(277, res.getDistance(), 1);
+
+        GHResponse rspSpeeds = hopperCustomSpeeds.route(request
+                .setProfile(carProfile));
+        ResponsePath resSpeeds = rspSpeeds.getBest();
+        assertFalse(rspSpeeds.hasErrors(), rspSpeeds.getErrors().toString());
+        assertEquals(21, resSpeeds.getTime() / 1000f, 1);  // 47kmh = 13.2m/s
+        assertEquals(277, resSpeeds.getDistance(), 1);
+
+        // the result with and without custom speeds should be the same when the custom speed is > than the max_speed
+        assertEquals(res.getTime() / 1000f, resSpeeds.getTime() / 1000f, 1);
+
+
+    }
+
+    @Test
+    public void testDynamicSpeedProviderDiscardCustomSpeedIfHigherThanMaxEncoderSpeed() {
+
+        // For bike, the max encoder speed is 30kmh
+        // For car, the max encoder speed is 254 kmh
+        // We are trying to set a custom speed for bike > 30kmh, that is the limit for the bike
+        // encoder, so we expect it to be discarded, and we expect that the default speed
+        // for those roads will be used
+
+        class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
+
+            @Override
+            public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
+                return Optional.of(new SpeedKmByHour(100));
+            }
+
+            @Override
+            public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
+                return Optional.of(new SpeedKmByHour(80.1));
+            }
+        }
+
+        final String bikeProfile = "bike_profile";
+
+        List<Profile> profiles = asList(
+                new Profile(bikeProfile).setVehicle("bike")
+        );
+
+        GraphHopper hopper = new GraphHopper().
+                setGraphHopperLocation(GH_LOCATION).
+                setOSMFile(MONACO).
+                setProfiles(profiles).
+                setStoreOnFlush(true);
+        hopper.getCHPreparationHandler().setCHProfiles(
+                new CHProfile(bikeProfile)
+        );
+
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
+                setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
+                setOSMFile(MONACO).
+                setProfiles(profiles).
+                setStoreOnFlush(true)
+                .setEncodedValuesString("roundabout, road_class, road_class_link, road_environment, max_speed, road_access, ferry_speed, bike_network, get_off_bike, smoothness, osm_way_id");
+        hopperCustomSpeeds.getCHPreparationHandler().setCHProfiles(
+                new CHProfile(bikeProfile)
+        );
+
+        hopper.importOrLoad();
+        hopperCustomSpeeds.importOrLoad();
+
+        GHRequest request = new GHRequest(43.73887, 7.42074, 43.73992, 7.42386);
+
+        GHResponse rspBike = hopper.route(request
+                .setProfile(bikeProfile));
+        ResponsePath resBike = rspBike.getBest();
+        assertFalse(rspBike.hasErrors(), rspBike.getErrors().toString());
+        assertEquals(55, resBike.getTime() / 1000f, 1); // 18kmh = 5 m/s
+        assertEquals(277, resBike.getDistance(), 1);
+
+        GHResponse rspBikeSpeeds = hopperCustomSpeeds.route(request
+                .setProfile(bikeProfile));
+        ResponsePath resBikeSpeeds = rspBikeSpeeds.getBest();
+        assertFalse(rspBikeSpeeds.hasErrors(), rspBikeSpeeds.getErrors().toString());
+        assertEquals(55, resBikeSpeeds.getTime() / 1000f, 1); // 17kmh = 4.7 m/s
+        assertEquals(277, resBikeSpeeds.getDistance(), 1);
+
+        // the result with and without custom speeds should be the same when the custom speed is > than the encoder limit
+        assertEquals(resBike.getTime() / 1000f, resBikeSpeeds.getTime() / 1000f, 1);
 
     }
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.stuart.platform.graphhopper</groupId>
             <artifactId>graphhopper-example</artifactId>
-            <version>5.1.1</version>
+            <version>5.1.2-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.stuart.platform.graphhopper</groupId>

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>  
 
     <dependencies>

--- a/map-matching/pom.xml
+++ b/map-matching/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
     
     <dependencies>

--- a/navigation/pom.xml
+++ b/navigation/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>  
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.stuart.platform.graphhopper</groupId>
     <artifactId>graphhopper-parent</artifactId>
     <name>GraphHopper Parent Project</name>
-    <version>5.1.1</version>
+    <version>5.1.2-SNAPSHOT</version>
     <packaging>pom</packaging>
     <url>https://www.graphhopper.com</url>
     <inceptionYear>2012</inceptionYear>

--- a/reader-gtfs/pom.xml
+++ b/reader-gtfs/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -9,7 +9,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
     <properties>
         <assembly-phase>package</assembly-phase>

--- a/web-api/pom.xml
+++ b/web-api/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/web-bundle/pom.xml
+++ b/web-bundle/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>com.stuart.platform.graphhopper</groupId>
         <artifactId>graphhopper-parent</artifactId>
-        <version>5.1.1</version>
+        <version>5.1.2-SNAPSHOT</version>
     </parent>
     <properties>
         <shade-phase>package</shade-phase>


### PR DESCRIPTION

## Jira Ticket
[RSPS-2011](https://stuart-team.atlassian.net/browse/RSPS-2011)

## Implementation details
Fix bug when we load a map with custom speeds, close it and the load the same map another time.
When do it GH is not using the correct max_speed for that transport.

We found that the problem was that GH once import the OSM file it stores the max_speed property of the speed encoder in a property file. And because we are setting the custom speeds after that, if we un load and reload the map GH will use the value store in that properties file.

To solve it after import the custom speed we need to save the encoder values another time in the properties files.

## Testing
I add a test simulating that behaviour.


[RSPS-2011]: https://stuart-team.atlassian.net/browse/RSPS-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ