### PR TITLE
[RSPS-2011]: Fix Bug Speed to high

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
+++ b/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
@@ -39,6 +39,10 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
         long endTime = System.nanoTime();
         long elapsed = (endTime - startTime);
         long durationInMillis = TimeUnit.NANOSECONDS.toMillis(elapsed);
+
+        //Save Encoding Manager Into Properties to have Max Speed in place after setting the new speeds
+        this.writeEncodingManagerToProperties();
+
         logger.info("End Custom Speeds Provider : Graph processed in " + durationInMillis);
     }
 

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -71,7 +71,7 @@ public class CustomModelParser {
                                                   EncodedValueLookup lookup, TurnCostProvider turnCostProvider, CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-        double maxSpeed = speedEnc.getMaxStorableDecimal();
+        double maxSpeed = speedEnc.getMaxOrMaxStorableDecimal();
         CustomWeighting.Parameters parameters = createWeightingParameters(customModel, lookup, speedEnc, maxSpeed, priorityEnc);
         return new CustomWeighting(accessEnc, speedEnc, turnCostProvider, parameters);
     }

--- a/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
+++ b/core/src/main/java/com/graphhopper/routing/weighting/custom/CustomModelParser.java
@@ -71,7 +71,7 @@ public class CustomModelParser {
                                                   EncodedValueLookup lookup, TurnCostProvider turnCostProvider, CustomModel customModel) {
         if (customModel == null)
             throw new IllegalStateException("CustomModel cannot be null");
-        double maxSpeed = speedEnc.getMaxOrMaxStorableDecimal();
+        double maxSpeed = speedEnc.getMaxStorableDecimal();
         CustomWeighting.Parameters parameters = createWeightingParameters(customModel, lookup, speedEnc, maxSpeed, priorityEnc);
         return new CustomWeighting(accessEnc, speedEnc, turnCostProvider, parameters);
     }


### PR DESCRIPTION
## Jira Ticket
[RSPS-2011](https://stuart-team.atlassian.net/browse/RSPS-2011)

## Implementation details
Fix bug when we load a map with custom speeds, close it and the load the same map another time.
When do it GH is not using the correct max_speed for that transport.

We found that the problem was that GH once import the OSM file it stores the max_speed property of the speed encoder in a property file. And because we are setting the custom speeds after that, if we un load and reload the map GH will use the value store in that properties file.

To solve it after import the custom speed we need to save the encoder values another time in the properties files.


[RSPS-2011]: https://stuart-team.atlassian.net/browse/RSPS-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ