### PR TITLE
RSPS-2048: Track Edges with/wihout custom speed in WaySpeedsProvider interface

### DIFF
--- a/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
+++ b/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
@@ -3,6 +3,7 @@ package com.graphhopper;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.ev.*;
 import com.graphhopper.routing.util.AllEdgesIterator;
+import com.graphhopper.speeds.Metrics;
 import com.graphhopper.speeds.SpeedKmByHour;
 import com.graphhopper.speeds.WaySpeedsProvider;
 import org.slf4j.Logger;
@@ -63,9 +64,11 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
         EnumEncodedValue<RoadClass> roadClassEncoder = this.getEncodingManager().getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
 
         AllEdgesIterator iter = this.getBaseGraph().getAllEdges();
+        Metrics metrics = new Metrics();
         while (iter.next()) {
 
             int edge = iter.getEdge();
+            metrics.incrementTotalNumberEdgesProcessed();
 
             //Normal Direction
             double maxSpeed = iter.get(maxSpeedEncoder);
@@ -82,6 +85,7 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
                         if(customSpeed <= maxEncoderValue && customSpeed >= minEncoderValue){
                             double speed = iter.get(encoder);
                             logger.debug("Replace " + speed + " with " + customSpeed + " for edge " + edge);
+                            metrics.incrementTotalNumberEdgesConfiguredWithCustomSpeed();
                             iter.set(encoder, customSpeed);
                         }else{
                             logger.warn("Invalid Custom Speed (" + customSpeed + ")  for encoder " + encoder.getName() + " ( " + minEncoderValue + " - " + maxEncoderValue+ ") for edge " + edge + ",so it will be ignored");
@@ -108,6 +112,7 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
                             if(customSpeedReverse <= maxEncoderValue && customSpeedReverse >= minEncoderValue){
                                 double speed = iter.getReverse(encoder);
                                 logger.debug("Replace " + speed + " with " + customSpeedReverse + " for edge reverse " + edge);
+                                metrics.incrementTotalNumberEdgesConfiguredWithCustomSpeedInReverse();
                                 iter.setReverse(encoder, customSpeedReverse);
                             }else{
                                 logger.warn("Invalid Custom Speed (" + customSpeedReverse + ") for encoder " + encoder.getName() + " ( " + minEncoderValue + " - " + maxEncoderValue+ ") for edge reverse " + edge + ",so it will be ignored");
@@ -121,5 +126,6 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
             }
 
         }
+        this.speedsProvider.setMetrics(metrics);
     }
 }

--- a/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
+++ b/core/src/main/java/com/graphhopper/GraphHopperCustomSpeeds.java
@@ -19,9 +19,10 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
     private static final Logger logger = LoggerFactory.getLogger(GraphHopperCustomSpeeds.class);
 
     private WaySpeedsProvider speedsProvider;
+    private Metrics metrics;
 
     public GraphHopperCustomSpeeds(WaySpeedsProvider speedsProvider) {
-
+        this.metrics = new Metrics();
         this.speedsProvider = speedsProvider;
     }
 
@@ -64,7 +65,6 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
         EnumEncodedValue<RoadClass> roadClassEncoder = this.getEncodingManager().getEnumEncodedValue(RoadClass.KEY, RoadClass.class);
 
         AllEdgesIterator iter = this.getBaseGraph().getAllEdges();
-        Metrics metrics = new Metrics();
         while (iter.next()) {
 
             int edge = iter.getEdge();
@@ -126,6 +126,9 @@ public class GraphHopperCustomSpeeds extends GraphHopper {
             }
 
         }
-        this.speedsProvider.setMetrics(metrics);
+    }
+
+    public Metrics getMetrics() {
+        return this.metrics;
     }
 }

--- a/core/src/main/java/com/graphhopper/speeds/Metrics.java
+++ b/core/src/main/java/com/graphhopper/speeds/Metrics.java
@@ -1,0 +1,39 @@
+package com.graphhopper.speeds;
+
+public class Metrics {
+
+    private double totalNumberEdgesProcessed;
+    private double totalNumberEdgesConfiguredWithCustomSpeed;
+    private double totalNumberEdgesConfiguredWithCustomSpeedInReverse;
+
+    public Metrics() {
+    }
+
+    public double getTotalNumberEdgesProcessed() {
+        return totalNumberEdgesProcessed;
+    }
+
+    public void incrementTotalNumberEdgesProcessed() {
+        totalNumberEdgesProcessed = totalNumberEdgesProcessed + 1;
+    }
+
+    public double getTotalNumberEdgesConfiguredWithCustomSpeed() {
+        return totalNumberEdgesConfiguredWithCustomSpeed;
+    }
+
+    public void incrementTotalNumberEdgesConfiguredWithCustomSpeed() {
+        totalNumberEdgesConfiguredWithCustomSpeed = totalNumberEdgesConfiguredWithCustomSpeed + 1;
+    }
+
+    public double getTotalNumberEdgesConfiguredWithoutCustomSpeed() {
+        return totalNumberEdgesProcessed - totalNumberEdgesConfiguredWithCustomSpeed;
+    }
+
+    public void incrementTotalNumberEdgesConfiguredWithCustomSpeedInReverse() {
+        totalNumberEdgesConfiguredWithCustomSpeedInReverse = totalNumberEdgesConfiguredWithCustomSpeedInReverse + 1;
+    }
+
+    public double getTotalNumberEdgesConfiguredWithoutCustomSpeedInReverse() {
+        return totalNumberEdgesProcessed - totalNumberEdgesConfiguredWithCustomSpeedInReverse;
+    }
+}

--- a/core/src/main/java/com/graphhopper/speeds/WaySpeedsProvider.java
+++ b/core/src/main/java/com/graphhopper/speeds/WaySpeedsProvider.java
@@ -7,6 +7,4 @@ import java.util.Optional;
 public interface WaySpeedsProvider {
     Optional<SpeedKmByHour> speedForWay(long osmWayId);
     Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass);
-    void setMetrics(Metrics metrics);
-    Metrics getMetrics();
 }

--- a/core/src/main/java/com/graphhopper/speeds/WaySpeedsProvider.java
+++ b/core/src/main/java/com/graphhopper/speeds/WaySpeedsProvider.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 public interface WaySpeedsProvider {
     Optional<SpeedKmByHour> speedForWay(long osmWayId);
     Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass);
+    void setMetrics(Metrics metrics);
+    Metrics getMetrics();
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
@@ -64,7 +64,6 @@ public class GraphHopperCustomSpeedsTest {
     public void testDynamicSpeedProvider() {
 
         class CustomWaySpeedProvider implements WaySpeedsProvider {
-            private final Metrics metrics = new Metrics();
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -143,7 +142,6 @@ public class GraphHopperCustomSpeedsTest {
     public void testDynamicSpeedProviderDiscardCustomSpeedIfHigherThanMaxSpeed() {
 
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
-            private final Metrics metrics = new Metrics();
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -215,8 +213,6 @@ public class GraphHopperCustomSpeedsTest {
 
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
 
-            private final Metrics metrics = new Metrics();
-
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
                 return Optional.of(new SpeedKmByHour(100));
@@ -284,8 +280,6 @@ public class GraphHopperCustomSpeedsTest {
         // For bike, the max encoder speed is 30kmh
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
 
-            private final Metrics metrics = new Metrics();
-
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
                 return Optional.of(new SpeedKmByHour(28));
@@ -302,7 +296,7 @@ public class GraphHopperCustomSpeedsTest {
         List<Profile> profiles = asList(
                 new Profile(bikeProfile).setVehicle("bike")
         );
-        
+
         GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS_RELOAD).
                 setOSMFile(MONACO).

--- a/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
@@ -94,8 +94,7 @@ public class GraphHopperCustomSpeedsTest {
                 new CHProfile(carProfile)
         );
 
-        CustomWaySpeedProvider provider = new CustomWaySpeedProvider();
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new CustomWaySpeedProvider()).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -170,8 +169,7 @@ public class GraphHopperCustomSpeedsTest {
                 new CHProfile(carProfile)
         );
 
-        SpeedsTooHighSpeedProvider provider = new SpeedsTooHighSpeedProvider();
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -245,8 +243,7 @@ public class GraphHopperCustomSpeedsTest {
                 new CHProfile(bikeProfile)
         );
 
-        SpeedsTooHighSpeedProvider provider = new SpeedsTooHighSpeedProvider();
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -305,9 +302,8 @@ public class GraphHopperCustomSpeedsTest {
         List<Profile> profiles = asList(
                 new Profile(bikeProfile).setVehicle("bike")
         );
-
-        SpeedsTooHighSpeedProvider provider = new SpeedsTooHighSpeedProvider();
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
+        
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS_RELOAD).
                 setOSMFile(MONACO).
                 setProfiles(profiles).

--- a/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
@@ -21,15 +21,17 @@ import com.graphhopper.config.CHProfile;
 import com.graphhopper.config.Profile;
 import com.graphhopper.routing.ev.RoadClass;
 import com.graphhopper.routing.ev.VehicleSpeed;
+import com.graphhopper.speeds.Metrics;
 import com.graphhopper.speeds.SpeedKmByHour;
 import com.graphhopper.speeds.WaySpeedsProvider;
-import com.graphhopper.util.*;
+import com.graphhopper.util.Helper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
 
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.*;
@@ -62,6 +64,7 @@ public class GraphHopperCustomSpeedsTest {
     public void testDynamicSpeedProvider() {
 
         class CustomWaySpeedProvider implements WaySpeedsProvider {
+            private Metrics metrics;
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -71,6 +74,16 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(10.1));
+            }
+
+            @Override
+            public void setMetrics(Metrics metrics) {
+                this.metrics = metrics;
+            }
+
+            @Override
+            public Metrics getMetrics() {
+                return this.metrics;
             }
         }
 
@@ -91,7 +104,8 @@ public class GraphHopperCustomSpeedsTest {
                 new CHProfile(carProfile)
         );
 
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new CustomWaySpeedProvider()).
+        CustomWaySpeedProvider provider = new CustomWaySpeedProvider();
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -132,12 +146,15 @@ public class GraphHopperCustomSpeedsTest {
         assertEquals(834, resBikeSpeeds.getTime() / 1000f, 1);
         assertEquals(2318, resBikeSpeeds.getDistance(), 1);
 
+        assertNotNull(provider.getMetrics());
+
     }
 
     @Test
     public void testDynamicSpeedProviderDiscardCustomSpeedIfHigherThanMaxSpeed() {
 
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
+            private Metrics metrics;
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -147,6 +164,16 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(80.1));
+            }
+
+            @Override
+            public void setMetrics(Metrics metrics) {
+                this.metrics = metrics;
+            }
+
+            @Override
+            public Metrics getMetrics() {
+                return this.metrics;
             }
         }
 
@@ -163,7 +190,8 @@ public class GraphHopperCustomSpeedsTest {
                 new CHProfile(carProfile)
         );
 
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
+        SpeedsTooHighSpeedProvider provider = new SpeedsTooHighSpeedProvider();
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -195,7 +223,7 @@ public class GraphHopperCustomSpeedsTest {
         // the result with and without custom speeds should be the same when the custom speed is > than the max_speed
         assertEquals(res.getTime() / 1000f, resSpeeds.getTime() / 1000f, 1);
 
-
+        assertNotNull(provider.getMetrics());
     }
 
     @Test
@@ -209,6 +237,8 @@ public class GraphHopperCustomSpeedsTest {
 
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
 
+            private Metrics metrics;
+
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
                 return Optional.of(new SpeedKmByHour(100));
@@ -217,6 +247,16 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(80.1));
+            }
+
+            @Override
+            public void setMetrics(Metrics metrics) {
+                this.metrics = metrics;
+            }
+
+            @Override
+            public Metrics getMetrics() {
+                return this.metrics;
             }
         }
 
@@ -235,7 +275,8 @@ public class GraphHopperCustomSpeedsTest {
                 new CHProfile(bikeProfile)
         );
 
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
+        SpeedsTooHighSpeedProvider provider = new SpeedsTooHighSpeedProvider();
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -267,6 +308,7 @@ public class GraphHopperCustomSpeedsTest {
         // the result with and without custom speeds should be the same when the custom speed is > than the encoder limit
         assertEquals(resBike.getTime() / 1000f, resBikeSpeeds.getTime() / 1000f, 1);
 
+        assertNotNull(provider.getMetrics());
     }
 
     @Test
@@ -274,6 +316,8 @@ public class GraphHopperCustomSpeedsTest {
 
         // For bike, the max encoder speed is 30kmh
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
+
+            private Metrics metrics;
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -284,6 +328,16 @@ public class GraphHopperCustomSpeedsTest {
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(28));
             }
+
+            @Override
+            public void setMetrics(Metrics metrics) {
+                this.metrics = metrics;
+            }
+
+            @Override
+            public Metrics getMetrics() {
+                return this.metrics;
+            }
         }
 
         final String bikeProfile = "bike_profile";
@@ -292,7 +346,8 @@ public class GraphHopperCustomSpeedsTest {
                 new Profile(bikeProfile).setVehicle("bike")
         );
 
-        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(new SpeedsTooHighSpeedProvider()).
+        SpeedsTooHighSpeedProvider provider = new SpeedsTooHighSpeedProvider();
+        GraphHopper hopperCustomSpeeds = new GraphHopperCustomSpeeds(provider).
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS_RELOAD).
                 setOSMFile(MONACO).
                 setProfiles(profiles).
@@ -306,7 +361,7 @@ public class GraphHopperCustomSpeedsTest {
 
         double maxSpeed = hopperCustomSpeeds.getEncodingManager().getDecimalEncodedValue(VehicleSpeed.key("bike")).getMaxOrMaxStorableDecimal();
 
-       hopperCustomSpeeds.close();
+        hopperCustomSpeeds.close();
 
         GraphHopper loadHopperCustomSpeeds = new GraphHopper().
                 setGraphHopperLocation(GH_LOCATION_CUSTOM_SPEEDS_RELOAD).
@@ -324,9 +379,9 @@ public class GraphHopperCustomSpeedsTest {
         loadHopperCustomSpeeds.close();
 
         assertEquals(maxSpeed, loadMaxSpeed, 1);
+        assertNotNull(provider.getMetrics());
 
     }
-
 
 
 }

--- a/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
+++ b/core/src/test/java/com/graphhopper/GraphHopperCustomSpeedsTest.java
@@ -64,7 +64,7 @@ public class GraphHopperCustomSpeedsTest {
     public void testDynamicSpeedProvider() {
 
         class CustomWaySpeedProvider implements WaySpeedsProvider {
-            private Metrics metrics;
+            private final Metrics metrics = new Metrics();
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -74,16 +74,6 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(10.1));
-            }
-
-            @Override
-            public void setMetrics(Metrics metrics) {
-                this.metrics = metrics;
-            }
-
-            @Override
-            public Metrics getMetrics() {
-                return this.metrics;
             }
         }
 
@@ -146,7 +136,7 @@ public class GraphHopperCustomSpeedsTest {
         assertEquals(834, resBikeSpeeds.getTime() / 1000f, 1);
         assertEquals(2318, resBikeSpeeds.getDistance(), 1);
 
-        assertNotNull(provider.getMetrics());
+        assertTrue(((GraphHopperCustomSpeeds) hopperCustomSpeeds).getMetrics().getTotalNumberEdgesProcessed() > 0);
 
     }
 
@@ -154,7 +144,7 @@ public class GraphHopperCustomSpeedsTest {
     public void testDynamicSpeedProviderDiscardCustomSpeedIfHigherThanMaxSpeed() {
 
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
-            private Metrics metrics;
+            private final Metrics metrics = new Metrics();
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -164,16 +154,6 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(80.1));
-            }
-
-            @Override
-            public void setMetrics(Metrics metrics) {
-                this.metrics = metrics;
-            }
-
-            @Override
-            public Metrics getMetrics() {
-                return this.metrics;
             }
         }
 
@@ -223,7 +203,7 @@ public class GraphHopperCustomSpeedsTest {
         // the result with and without custom speeds should be the same when the custom speed is > than the max_speed
         assertEquals(res.getTime() / 1000f, resSpeeds.getTime() / 1000f, 1);
 
-        assertNotNull(provider.getMetrics());
+        assertTrue(((GraphHopperCustomSpeeds) hopperCustomSpeeds).getMetrics().getTotalNumberEdgesProcessed() > 0);
     }
 
     @Test
@@ -237,7 +217,7 @@ public class GraphHopperCustomSpeedsTest {
 
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
 
-            private Metrics metrics;
+            private final Metrics metrics = new Metrics();
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -247,16 +227,6 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(80.1));
-            }
-
-            @Override
-            public void setMetrics(Metrics metrics) {
-                this.metrics = metrics;
-            }
-
-            @Override
-            public Metrics getMetrics() {
-                return this.metrics;
             }
         }
 
@@ -308,7 +278,7 @@ public class GraphHopperCustomSpeedsTest {
         // the result with and without custom speeds should be the same when the custom speed is > than the encoder limit
         assertEquals(resBike.getTime() / 1000f, resBikeSpeeds.getTime() / 1000f, 1);
 
-        assertNotNull(provider.getMetrics());
+        assertTrue(((GraphHopperCustomSpeeds) hopperCustomSpeeds).getMetrics().getTotalNumberEdgesProcessed() > 0);
     }
 
     @Test
@@ -317,7 +287,7 @@ public class GraphHopperCustomSpeedsTest {
         // For bike, the max encoder speed is 30kmh
         class SpeedsTooHighSpeedProvider implements WaySpeedsProvider {
 
-            private Metrics metrics;
+            private final Metrics metrics = new Metrics();
 
             @Override
             public Optional<SpeedKmByHour> speedForWay(long osmWayId) {
@@ -327,16 +297,6 @@ public class GraphHopperCustomSpeedsTest {
             @Override
             public Optional<SpeedKmByHour> speedForRoadClass(RoadClass roadClass) {
                 return Optional.of(new SpeedKmByHour(28));
-            }
-
-            @Override
-            public void setMetrics(Metrics metrics) {
-                this.metrics = metrics;
-            }
-
-            @Override
-            public Metrics getMetrics() {
-                return this.metrics;
             }
         }
 
@@ -379,7 +339,7 @@ public class GraphHopperCustomSpeedsTest {
         loadHopperCustomSpeeds.close();
 
         assertEquals(maxSpeed, loadMaxSpeed, 1);
-        assertNotNull(provider.getMetrics());
+        assertTrue(((GraphHopperCustomSpeeds) hopperCustomSpeeds).getMetrics().getTotalNumberEdgesProcessed() > 0);
 
     }
 


### PR DESCRIPTION
## Jira Ticket
[RSPS-2048](https://stuart-team.atlassian.net/browse/RSPS-2048)

## Implementation details
Track metrics about how many edges were configured with custom speeds. This will be useful to establish rules on the volume manager.

## Examples


## Testing
If necessary add description on what is tested locally and all the types of tests you added.


[RSPS-2048]: https://stuart-team.atlassian.net/browse/RSPS-2048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ